### PR TITLE
allow timeout to be configurable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['release']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['release']
+    branches: ['master']
 
 env:
   REGISTRY: ghcr.io

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Host picking strategy:
 Measurement options:
 
 - `-p int`: Interval in milliseconds at which to perform the ping measurement. A value of -1 disables this test. Results recorded to the `ping_rtt_ms` and `ping_failures_total` metrics with the `target_host` label. (default 10000)
+- `-o int`: Interval in milliseconds for which a ping attempt will timeout. (default 30000)
 
 Other options:
 

--- a/main.go
+++ b/main.go
@@ -16,9 +16,6 @@ import (
 // PING_COUNT is the number of ping packets sent to determine the average round trip time.
 const PING_COUNT int = 1
 
-// PING_TIMEOUT_MS is the number of milliseconds before a ping attempt will timeout. 30 seconds.
-const PING_TIMEOUT_MS int = 30000
-
 // log is the application logger.
 var log golog.Logger = golog.NewLogger("net-test")
 
@@ -101,6 +98,12 @@ func main() {
 		10000,
 		fmt.Sprintf("Interval in milliseconds at which to perform the ping measurement. Will perform %d ping(s). A value of -1 disables this test. Results recorded to the \"ping_rtt_ms\" and \"ping_failures_total\" metrics with the \"target_host\" label.", PING_COUNT))
 
+	var timeoutMs int
+	flag.IntVar(&timeoutMs,
+		"o",
+		30000,
+		"Change timeout of the ping")
+
 	flag.Parse()
 
 	if len(targetHosts.Get()) == 0 {
@@ -169,7 +172,7 @@ func main() {
 					}
 					pinger.Count = PING_COUNT
 					pinger.SetPrivileged(true)
-					pinger.Timeout = time.Duration(PING_TIMEOUT_MS) * time.Millisecond
+					pinger.Timeout = time.Duration(timeoutMs) * time.Millisecond
 
 					pingers = append(pingers, pinger)
 				}


### PR DESCRIPTION
Hi,
Not sure if this is useful for you,

but I had a use case where I needed to detect very short outages, and so I've tweaked it so the timeout can be overwritten